### PR TITLE
Treat an apostrophe as ending a word so elided articles match

### DIFF
--- a/hassil/string_matcher.py
+++ b/hassil/string_matcher.py
@@ -50,6 +50,18 @@ INTEGER_ANYWHERE = re.compile(r"(\s*-?[0-9]+)")
 FLOAT_ANYWHERE = re.compile(r"(\s*-?[0-9]+(?:[.,][0-9]+)?)")
 BREAK_WORDS_TABLE = str.maketrans("-_", "  ")
 
+# Characters that end a word without a space following them.
+#
+# Languages with elision attach the article directly to the next word:
+# "nell'ingresso" (it), "l'entrée" (fr), "l'aigua" (ca). Sentence templates put
+# a literal space after the article, as in "<in> [<the>] {area}", so unless the
+# apostrophe is treated as ending a word the elided form only matches when the
+# speaker writes "nell' ingresso", which nobody does.
+#
+# Both the ASCII apostrophe and the typographic one are included: keyboards and
+# autocorrect disagree about which they produce, and the speaker did not choose.
+WORD_END_CHARS = (" ", "'", "’")
+
 # lang -> number -> words
 _RANGE_TRIE_CACHE: Dict[
     str, Dict[Tuple[int, int, int, Optional[RangeFractionType]], Trie]
@@ -337,7 +349,7 @@ def match_expression(
                 yield MatchContext(
                     text=context_text,
                     # must use chunk.text because it hasn't been stripped
-                    is_start_of_word=chunk.text.endswith(" "),
+                    is_start_of_word=chunk.text.endswith(WORD_END_CHARS),
                     text_chunks_matched=text_chunks_matched,
                     text_index=base_index + end_pos,
                     # Copy over

--- a/tests/test_recognize.py
+++ b/tests/test_recognize.py
@@ -164,6 +164,92 @@ intents:
         assert result.entities["name"].value == "climate.ac"
 
 
+def test_elided_article_without_space():
+    """An elided article attaches to the next word: "nell'ingresso", "l'entrée"."""
+    # Shaped like the real it/fr templates, where the expansion rule carries its
+    # own trailing space and the sentence adds another one before the slot.
+    yaml_text = """
+language: "it"
+intents:
+  GetState:
+    data:
+      - sentences:
+          - "quante luci sono accese <in> [<the>] {area}"
+expansion_rules:
+  in: "(dentro |in | ne[l |i |gli |llo |lla |lle |ll'[ ]])"
+  the: "(l(o |a |e )|i[l] |gli |l'[ ])"
+"""
+    with io.StringIO(yaml_text) as yaml_file:
+        intents = Intents.from_yaml(yaml_file)
+
+    slot_lists = {
+        "area": TextSlotList.from_tuples(
+            [("ingresso", "area.ingresso"), ("soggiorno", "area.soggiorno")]
+        )
+    }
+
+    # Elided, as the language is actually written and spoken.
+    for text in (
+        "quante luci sono accese nell'ingresso",
+        "quante luci sono accese nell’ingresso",
+        # Still accepted with a space, so existing sentences keep matching.
+        "quante luci sono accese nell' ingresso",
+    ):
+        result = recognize(text, intents, slot_lists=slot_lists)
+        assert result is not None, text
+        assert result.entities["area"].value == "area.ingresso", text
+
+    # Unelided forms must not regress.
+    for text in (
+        "quante luci sono accese nel soggiorno",
+        "quante luci sono accese in soggiorno",
+        "quante luci sono accese dentro il soggiorno",
+    ):
+        result = recognize(text, intents, slot_lists=slot_lists)
+        assert result is not None, text
+        assert result.entities["area"].value == "area.soggiorno", text
+
+    # An apostrophe does not license a missing word.
+    assert (
+        recognize("quante luci sono accese nell'atrio", intents, slot_lists=slot_lists)
+        is None
+    )
+
+
+def test_elided_article_before_name():
+    """The same applies to a name: "l'aria condizionata è accesa"."""
+    yaml_text = """
+language: "it"
+intents:
+  GetState:
+    data:
+      - sentences:
+          - "[<the>] {name} è accesa"
+expansion_rules:
+  the: "(l(o |a |e )|i[l] |gli |l'[ ])"
+"""
+    with io.StringIO(yaml_text) as yaml_file:
+        intents = Intents.from_yaml(yaml_file)
+
+    slot_lists = {
+        "name": TextSlotList.from_tuples(
+            [
+                ("aria condizionata", "climate.ac"),
+                ("lavastoviglie", "switch.dishwasher"),
+            ]
+        )
+    }
+
+    for text in ("l'aria condizionata è accesa", "l’aria condizionata è accesa"):
+        result = recognize(text, intents, slot_lists=slot_lists)
+        assert result is not None, text
+        assert result.entities["name"].value == "climate.ac", text
+
+    result = recognize("la lavastoviglie è accesa", intents, slot_lists=slot_lists)
+    assert result is not None
+    assert result.entities["name"].value == "switch.dishwasher"
+
+
 # pylint: disable=redefined-outer-name
 def test_brightness_area(intents, slot_lists):
     result = recognize(


### PR DESCRIPTION
In Italian the article elides onto the word that follows it — you say
`nell'ingresso`, never `nell' ingresso`. French and Catalan do the same
(`l'entrée`, `l'aigua`). Today those sentences don't match, and it took me a
while to work out why, because the language rules look correct:

```
<in>  = (all'interno |dentro |in | ne[l |i |gli |llo |lla |lle |ll'[ ]])
<the> = (l(o |a |e )|i[l] |gli |l'[ ])
```

The elided alternatives are there, and they even make the following space
optional. The catch is on the other side: the sentence is
`<in> [<the>] {area}`, which puts a *literal* space after the article. The
expansion rules already carry their own trailing space, so that extra space
ends up being required, and the only form that matches is the one with a space
after the apostrophe:

| input | before | after |
|---|---|---|
| `quante luci sono accese nell'ingresso` | ✗ | ✓ |
| `quante luci sono accese nell’ingresso` | ✗ | ✓ |
| `quante luci sono accese nell' ingresso` | ✓ | ✓ |
| `quante luci sono accese nel soggiorno` | ✓ | ✓ |
| `combien de lumières sont allumées dans l'entrée` | ✗ | ✓ |
| `combien de lumières sont allumées dans le salon` | ✓ | ✓ |

The matcher already has exactly the right mechanism for this. When a chunk ends
a word, `is_start_of_word` lets the next chunk *and* the text skip leading
whitespace — that is what makes the space after `nel ` flexible. It was derived
from a trailing space alone, so `nell'` didn't qualify. An apostrophe ends a
word just as a space does, so this includes it:

```python
WORD_END_CHARS = (" ", "'", "’")
...
is_start_of_word=chunk.text.endswith(WORD_END_CHARS),
```

Both apostrophe characters are accepted, since keyboards and autocorrect
disagree about which they produce and the speaker didn't choose. That is a
smaller thing than #2086 (which is about matching an apostrophe inside a *name*)
and doesn't address it.

I looked at fixing this in `intents` instead, by dropping the literal spaces so
the sentence reads `<in>[<the>]{area}`. It works, but it means touching ~39
`<in> ` and ~246 `[<the>] ` occurrences in Italian alone, then French, and
getting it right in every sentence added afterwards. Since the rules already
express the intent, it seemed better to fix the one place that decides where a
word ends.

Sentences written with a space after the article keep matching, so no existing
template or test needed changing. Added two tests, shaped like the real it/fr
templates, covering both apostrophe characters, the spaced form, the unelided
forms, and a check that an apostrophe doesn't license matching a word that
isn't there. Full suite passes (160), and `black`/`isort`/`flake8`/`pylint`
are clean — `mypy` reports only the pre-existing missing PyYAML stubs.

Found this running a household Assist pipeline in Italian, where "accendi le
luci nell'ingresso" is simply how the sentence is said.
