### PR TITLE
Normalize text before removing punctuation when matching

### DIFF
--- a/hassil/util.py
+++ b/hassil/util.py
@@ -390,8 +390,14 @@ def remove_punctuation(text: str) -> str:
 def normalize_for_matching(text: str) -> TrackedText:
     """Return match-ready text with a map back into the original text."""
     tracked = TrackedText(text)
-    _remove_punctuation(tracked)
+
+    # Normalize before removing punctuation. "’" is punctuation but "'" is not,
+    # so stripping first deletes a typographic apostrophe wherever a word ends
+    # ("nell’ ingresso" -> "nell ingresso") instead of folding it to the ASCII
+    # form the templates use. Normalizing first makes both apostrophes behave
+    # the same everywhere.
     _normalize_text(tracked)
+    _remove_punctuation(tracked)
     tracked.strip()
 
     return tracked

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,7 @@
 from hassil.util import (
     is_template,
     merge_dict,
+    normalize_for_matching,
     normalize_text,
     normalize_whitespace,
     remove_escapes,
@@ -48,3 +49,16 @@ def test_remove_punctuation():
     assert remove_punctuation("Main St. next") == "Main St next"
     assert remove_punctuation("Chambre d'Ariane") == "Chambre d'Ariane"
     assert remove_punctuation("Chambre d’Ariane") == "Chambre d’Ariane"
+
+
+def test_normalize_for_matching_apostrophes():
+    """Both apostrophes normalize the same way, whatever follows them."""
+    # Templates only ever contain "'", so "’" has to reach the matcher as "'"
+    # rather than being stripped as punctuation.
+    assert normalize_for_matching("nell'ingresso").text == "nell'ingresso"
+    assert normalize_for_matching("nell’ingresso").text == "nell'ingresso"
+    assert normalize_for_matching("nell' ingresso").text == "nell' ingresso"
+    assert normalize_for_matching("nell’ ingresso").text == "nell' ingresso"
+
+    # Punctuation removal still happens afterwards.
+    assert normalize_for_matching("ciao, come va?").text == "ciao come va"


### PR DESCRIPTION
`normalize_for_matching()` strips punctuation before it normalizes. `’` is in
`PUNCTUATION_STR` and `'` is not, so a typographic apostrophe that ends a word
gets deleted rather than folded to the ASCII form:

| input | today | after |
|---|---|---|
| `nell'ingresso` | `nell'ingresso` | `nell'ingresso` |
| `nell’ingresso` | `nell'ingresso` | `nell'ingresso` |
| `nell' ingresso` | `nell' ingresso` | `nell' ingresso` |
| `nell’ ingresso` | `nell ingresso` | `nell' ingresso` |

Templates only ever contain `'` — `normalize_text()` rewrites `’` when they are
parsed — so the last row cannot match a template that spells out an elided
article, while the byte-identical ASCII form can. Which apostrophe a speaker's
keyboard produced should not decide whether the sentence matches.

Swapping the two calls folds `’` to `'` before punctuation removal sees it, so
both apostrophes behave the same in every position. Punctuation removal is
otherwise unchanged (`ciao, come va?` → `ciao come va`), and `_is_same_source_char()`
already maps `’` → `'`, so `text_span` still resolves back into the original text.
`normalize_for_matching()` is the only place that composes the two helpers.

Full suite passes (159, one added), `black`/`isort`/`flake8`/`pylint` clean. Also
ran the `OHF-Voice/intents` suite against this branch: 14816 passed, unchanged
from `main`.

### Relationship to #281

Independent, and neither blocks the other. #281 makes `nell'ingresso` match by
treating an apostrophe as ending a word; this makes `nell’ ingresso` normalize to
the same text as `nell' ingresso`. Together they cover all four spellings. This
one touches only normalization and changes no matching logic.

Found while reviewing #281 (from OHF-Voice/intents#4183).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
